### PR TITLE
included API documentation

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -3,15 +3,14 @@ layout: article
 title: User Manual
 ---
 
-{% include toc.html %}
+<!-- {% include toc.html %} -->
 
-## [FAQ][0]
+# [API Documentation][0]
 
-click [here][0]
+# [FAQ][1]
 
-## [Video Tutorials][1]
+# [Video Tutorials][2]
 
-click [here][1]
-
-[0]: /doc/faq "FAQ"
-[1]: /doc/tutorials "Video Tutorials"
+[0]: https://pencil2d.github.io/pencil-docs/docs/ "API Documentation"
+[1]: /doc/faq "FAQ"
+[2]: /doc/tutorials "Video Tutorials"


### PR DESCRIPTION
For now it's just a simple link to the documentation. We should look into [moxygen](https://github.com/sourcey/moxygen) though, for a prettier representation of the API. Also, the API index page is messed up, it shouldn't contain the front page with download links and all that.