### PR TITLE
Add installation instructions for Arch Linux

### DIFF
--- a/download/index.md
+++ b/download/index.md
@@ -63,6 +63,10 @@ Last Updated on 1 December 2017. See
 <div style="clear:both"></div>
 
 
+### Arch Linux
+
+Pencil2D is available for Arch Linux through the package [pencil2d](https://aur.archlinux.org/packages/pencil2d) on the AUR. If you are not yet familiar with the process of building and installing packages from the AUR, please follow [the tutorial on the Arch Wiki](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages).
+
 ### Debian & Ubuntu
 
 ```


### PR DESCRIPTION
Since the OS-specific sections seemed to be ordered alphabetically, I put Arch on top. As installing packages from the AUR is slightly more involved than just `pacman -S <package>`, the entry serves more as a heads-up rather than the kind of copy-and-paste instructions we have for Debian/Ubuntu and macOS.
![127-0-0-1-4000-2018-01-14-17-20-33-975](https://user-images.githubusercontent.com/2063777/34918198-4f850f76-f94f-11e7-8a41-1c51422f8162.png)