### PR TITLE
Make troubleshooting for missing DLLs (esp. MSVC) more visible

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -9,6 +9,10 @@ comments: true
 
 {% include toc.html %}
 
+## The program can't start because some .dll file is missing!
+
+Depending on the name of the missing file, this error can occur for different reasons. Please see [the Troubleshooting section of our download page](/download/#troubleshooting) for some of the most common cases. If your particular case isn't solved there, please [let us know](/community/).
+
 ## Where's the [Insert OS here] version? Why isn't my [OS] version updated?
 
 At the time of writing, Pencil2D can run on:

--- a/download/index.md
+++ b/download/index.md
@@ -12,6 +12,11 @@ Last Updated on 1 December 2017. See
 <a href="/2017/12/introducing-pencil2d-0.6.html">What's New</a> in v0.6.
 </blockquote>
 
+<blockquote style="color:#898989;font-size:0.8em">
+If you have trouble running the program, please see the
+<a href="#troubleshooting">Troubleshooting section</a> below.
+</blockquote>
+
 <div class="download-tiles">
 <div></div>
 <div class="download-tile">
@@ -92,7 +97,7 @@ Nightly builds are the bleeding edge versions of Pencil2D, which contains the mo
 [2]: https://goo.gl/PXsLCI
 [3]: https://goo.gl/NQuJYr
 
-## Troubleshooting
+## Troubleshooting {#troubleshooting}
 
 **Qt5Widgets.dll was not found**
 
@@ -101,10 +106,8 @@ Nightly builds are the bleeding edge versions of Pencil2D, which contains the mo
 
 **msvcp140.dll is missing**
 
-- Please install `vc_redist.x64.exe` or `vc_redist.x86.exe`, you can find it in the same folder of Pencil2D.exe after you extract the zip.
+- Please install `vcredist_x64.exe` or `vcredist_x86.exe`, you can find it in the same folder of Pencil2D.exe after you extract the zip.
 
 **api-ms-win-crt-runtime-l1-1-0.dll is missing**
 
 - Please follow the instructions of this [Microsoft Help Page](https://support.microsoft.com/en-us/help/2999226/update-for-universal-c-runtime-in-windows).
-
-


### PR DESCRIPTION
Recently another user reported problems due to a missing MSVC runtime, so it’s probably a good idea to make our troubleshooting information for such cases more discoverable. I also adjusted the name of the redist installer programs to match our current downloads.