### PR TITLE
Animate collapsing dropdown menu

### DIFF
--- a/_sass/blog/_layout.scss
+++ b/_sass/blog/_layout.scss
@@ -129,10 +129,10 @@
         -webkit-transform: scaleY(0);
         -ms-transform: scaleY(0);
 
-        transition: transform 0.25s ease;
-        -webkit-transition: transform 0.25s ease;
-        -moz-transition: transform 0.25s ease;
-        -o-transition: transform 0.25s ease;
+        transition: transform 0.25s ease, visibility 0.25s step-end;
+        -webkit-transition: transform 0.25s ease, visibility 0.25s step-end;
+        -moz-transition: transform 0.25s ease, visibility 0.25s step-end;
+        -o-transition: transform 0.25s ease, visibility 0.25s step-end;
 
         min-width: 160px;
 
@@ -152,6 +152,10 @@
           transform: scaleY(1);
           -webkit-transform: scaleY(1);
           -ms-transform: scaleY(1);
+          transition: transform 0.25s ease, visibility 0.25s step-start;
+          -webkit-transition: transform 0.25s ease, visibility 0.25s step-start;
+          -moz-transition: transform 0.25s ease, visibility 0.25s step-start;
+          -o-transition: transform 0.25s ease, visibility 0.25s step-start;
         }
       }
     }


### PR DESCRIPTION
Turns out there is a pretty straightforward way to have a collapsing animation, after all. And unless I’m mistaken, this should also have pretty good backwards compatibility – [According to Can i use](https://caniuse.com/#feat=css-transitions), the only browsers that support transitions but no step-start and step-end are some pretty old versions of Chrome and Safari, which now have a combined global usage of ~0.05%.