### PR TITLE
Improve hover behaviour of SVG icons

### DIFF
--- a/_includes/mystyle.css
+++ b/_includes/mystyle.css
@@ -194,7 +194,7 @@
 
 .download-size { color: #aaa; }
 path{fill:#00438c;}
-path:hover{fill:#ef8003;}
+a:hover path{fill:#ef8003;}
 
 .download-table table {
     table-layout: fixed;


### PR DESCRIPTION
Before:

![Before](https://user-images.githubusercontent.com/2063777/43644032-904be7a6-972d-11e8-8191-dc176d4bcdbb.gif)

After:

![After](https://user-images.githubusercontent.com/2063777/43644044-9cefc932-972d-11e8-882f-0fdd614e7148.gif)

Note that while I’m using the docs page as an example, this change also applies to the footer icons as well as the OS icons on the download page.