### PR TITLE
Release highlight videos & Delay explanation

### DIFF
--- a/_posts/2020-07-31-pencil2d-0.6.5-release.md
+++ b/_posts/2020-07-31-pencil2d-0.6.5-release.md
@@ -24,7 +24,7 @@ comments: false
 
 ## <a id="#download"><a/>Pencil2D Release Version 0.6.5
 
-It's been well over **1 year** since our last release. Many things have happened for all of us and even though we are still performing post-release tasks, we have persevered to get this version with **over 600+ individual tasks**. Thus we are releasing Pencil2D v0.6.5 into the wild!
+It's been well over **1 year** since our last release. Many things have happened for all of us and even though we are still performing post-release tasks and fixing unforeseen bugs, we have persevered to get this version with **over 600+ individual tasks**. Thus we are releasing Pencil2D v0.6.5 into the wild!
 
 [Download v0.6.5][0]!
 
@@ -42,56 +42,46 @@ Many thanks to all the people who helped to make this release possible.
 [josemoreno]: https://github.com/jose-moreno
 [mc-csharpclass]: https://github.com/mc-csharpclass
 
-## <a id="#intro"><a/>Pencil2D Release 0.6.5
+## <a id="#intro"><a/>Pencil2D Release 0.6.5, 28 days later
 
-Truth be told we were attempting a new release strategy, but during this experimental phase the version release became more and more ambitious for a proper "feature release", and we realized this as we tried to push for compatibility breaking changes, however most of our team had a reality check in both their personal and professional lives and we had to decide that it was time to release a new Pencil2D version to update your experience.
+...Well actually make that 40 *gasp*. Truth be told the application has been out since July 31st 2020. While we were working on a new release strategy the release version became more and more ambitious, however most of our team had a reality check with both their personal and professional lives so we had to decide that it was time to release a new, albeit impefect, version to update your experience.
 
-During this past year unfortunately we've been dealing with additional issues on each of our beloved operating systems, and since their latest iterations a new wave of security lock-in's have been appearing, typical of proprietary vendors, which has caused a lot of trouble for the open-source community as well as Pencil2D users, as they can't circumvent these "features" due to lacking administration rights for their systems. [If you'd like to know what we've done and what you can do, read on](#permissions)! but before you get into the release notes highlighs [we have a surprise](#showcase) for everyone!
+The lack of a timely announcement was a byproduct of our desire that all platforms we support officially or through external maintainers were ready before the announcent. This time we also wanted to provide a bit more explanation on how the new features are used, so we produced a few video overviews to help with this.
+
+We're still working though. Right now we're furiously addressing new bugs that have appeared due to the newest features, and finally putting to rest other issues that have been chasing us for years. We kindly ask everyone to please follow closely the bug tracker, as we will be also looking to release a new bug fix version, 0.6.6 by the end of september / start of october to address some of the most critical [Known issues](#known-issues) you'll find right off the bat.
+
+Lastly, during this past year we've been also dealing with additional issues introduced by traditional operating systems, and after the new wave of security updates, the open-source community, as well as Pencil2D users have been reporting various issues related to file permissions. [If you'd like to know what we've done to ease this problem and what you can do, read on](#permissions)! 
+
+Before you dive into the current [release notes](#release-notes) or the new [feature highligths](#highlights) [we have a surprise](#showcase) for everyone!
 
 ## <a id="#pclshowcase"><a/>Pencil2D User Showcase 2020
 
-During May we made a call for content in order to update our **User Showcase** for 2020. Suffice to say we are overjoyed with the work that was sent and we're proud of this community. While we couldn't accomodate everyone, we did our best so each contributing artist would be featured and we edited the video to higlight their work. We hope you enjoy it
+Back in May we made a call for content in order to update our **User Showcase** for 2020. Suffice to say we are overjoyed with the work that was sent and we're proud of this community. While we couldn't accomodate everyone, we did our best so each contributing artist would be featured and we edited the video artistically to higlight their own work. We hope you enjoy it!
 
-[![Pencil2D Showcase Reel 2020](http://img.youtube.com/vi/ma52j9B1kEM/hqdefault.jpg)](https://youtu.be/ma52j9B1kEM)
+## Pencil2D Showcase Reel 2020
+<div style="text-align: center;">  
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/ma52j9B1kEM" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
 
 ## <a id="#highlights"><a/>Release Highlights
 
-### Movie Import
+We also took some time to provide quick video guides to each of the new major features that have landed in Pencil2D. While humble, these will certainly improve over time with your feedback and support. Enjoy!
 
-[![Movie Import Review](http://img.youtube.com/vi/ma52j9B1kEM/hqdefault.jpg)](https://youtu.be/ma52j9B1kEM)
-![Movie Import]({{ "/images/pencil2d-movie-import.gif" | relative_url }})
+|**Movie Import**   |**Sound Scrubbing**   |**Project File Template Presets**   |
+|---|---|---|
+|[![Movie Import Review](http://img.youtube.com/vi/ZPrHrYr0U64/hqdefault.jpg)](https://youtu.be/ZPrHrYr0U64)   |[![Sound Scrubbing Review](http://img.youtube.com/vi/_osSf24halI/hqdefault.jpg)](https://youtu.be/_osSf24halI)   |[![Startup Presets Review](http://img.youtube.com/vi/3ZU8QtMCrI0/hqdefault.jpg)](https://youtu.be/3ZU8QtMCrI0)   |
 
-### Sound Scrubbing
+|**Pixel Tracker (Simple peg-bar alignment)**   |**Pixel Re-coloring**   |**Import Re-position**   |
+|---|---|---|
+|[![Pegbar Alignment Review](http://img.youtube.com/vi/NhuCd5PQ7Dw/hqdefault.jpg)](https://youtu.be/NhuCd5PQ7Dw)   |[![Pixel ReColor Review](http://img.youtube.com/vi/K7ulc2sOQjA/hqdefault.jpg)](https://youtu.be/K7ulc2sOQjA)   |[![Project Layer Import Review](http://img.youtube.com/vi/7jY-Omn6b6c/hqdefault.jpg)](https://youtu.be/7jY-Omn6b6c)   |
 
-[![Sound Scrubbing Review](http://img.youtube.com/vi/ma52j9B1kEM/hqdefault.jpg)](https://youtu.be/ma52j9B1kEM)
+|**Rotation Angle Constraint**   |**Camera Overlay System**   |**Light Table mode**   |
+|---|---|---|
+|[![Rotation Constraint Review](http://img.youtube.com/vi/lP0MNeFhV7g/hqdefault.jpg)](https://youtu.be/lP0MNeFhV7g)   |[![Camera Overlay Review](http://img.youtube.com/vi/E3x8CeHQp54/hqdefault.jpg)](https://youtu.be/E3x8CeHQp54)   |[![Light Table Review](http://img.youtube.com/vi/IwKRJaRxgeU/hqdefault.jpg)](https://youtu.be/IwKRJaRxgeU)   |
 
-### Project File Template Presets
-
-[![Startup Presets Review](http://img.youtube.com/vi/ma52j9B1kEM/hqdefault.jpg)](https://youtu.be/ma52j9B1kEM)
-
-### Simple Registration Alignment (Pixel Position Matching)
-
-[![Pegbar Alignment Review](http://img.youtube.com/vi/ma52j9B1kEM/hqdefault.jpg)](https://youtu.be/ma52j9B1kEM)
-
-### Pixel ReColor
-
-[![Pixel ReColor Review](http://img.youtube.com/vi/ma52j9B1kEM/hqdefault.jpg)](https://youtu.be/ma52j9B1kEM)
-
-### External Pencil2D Project Layer Import
-
-[![Project Layer Import Review](http://img.youtube.com/vi/ma52j9B1kEM/hqdefault.jpg)](https://youtu.be/ma52j9B1kEM)
-
-### Rotation Angle Constraint
-
-[![Rotation Constraint Review](http://img.youtube.com/vi/ma52j9B1kEM/hqdefault.jpg)](https://youtu.be/ma52j9B1kEM)
-
-### Camera Overlay System
-
-[![Camera Overlay Review](http://img.youtube.com/vi/ma52j9B1kEM/hqdefault.jpg)](https://youtu.be/ma52j9B1kEM)
-
-### Light Table mode
-
-[![Light Table Review](http://img.youtube.com/vi/ma52j9B1kEM/hqdefault.jpg)](https://youtu.be/ma52j9B1kEM)
+|**Pencil2D Project Layer Import**   |
+|---|
+|[![Project Layer Import](http://img.youtube.com/vi/7jY-Omn6b6c/hqdefault.jpg)](https://youtu.be/7jY-Omn6b6c)   |
 
 ## <a id="#permissions"><a/>Windows & MacOS Permissions Issues
 
@@ -187,6 +177,13 @@ https://support.apple.com/en-us/HT202491 (How to bypass signing and notarization
 ## <a id="#known-issues"><a/>Known Issues & Gotchas
 
 Here is a non-exhaustive list of bugs that we are already aware of, but were unable to fix in this release. Rest assured, we will do our best to fix all of them eventually.
+
+- [#1417] Panels spilling their content or timeline getting pushed outside the scree when the vertical screen size is too narrow, usually on 1366x768 laptops (this was partially addressed by #1369 already)
+- [#1426] Onion skins, layers & documents show "ghosted" (buffered) images after creating a selection
+- [#1427] Crash when importing multiple PCLX layers using the same dialog with the new Pencil2D project import feature
+- [#1428] Crash when creating new file after using peg-bar alignment
+- [#1429] Unoding a stroke made in an empty frame, relative to an existing keyframe will create a new keyframe instead and mess up the undo order.
+- [#1433] & [#1435] Polyline tool drawing not updating properly while drawing on vector & bitmap layers respectively.
 
 - Zooming out the camera layer to less than 25% will increase the chance of Crashing Pencil2D
 - [#748](https://github.com/pencil2d/pencil/issues/748), [#1004](https://github.com/pencil2d/pencil/issues/1004), [#1098](https://github.com/pencil2d/pencil/issues/1098) Misc undo/redo issues. **New Undo / Redo system under development** will be reviewed for v0.7.0


### PR DESCRIPTION
- Added a table format to contain the feature highlights and reduce vertical space
- Noticed one video is pending to be produced. I'll get to it ASAP but if we want to publish this just remove the last table with a single element
- Updated known issues, pending links
    - Pending to add critically reported sound related issues (e.g single sound keyframe, sound / movie audio import bug, etc)