### PR TITLE
Replaced Rotate Image Video

### DIFF
--- a/doc/tutorials.md
+++ b/doc/tutorials.md
@@ -13,7 +13,7 @@ tagline: Learn how to use & animate with Pencil2D!
 | -----------------------------------------------| ------------------ |
 | [Pencil2D Tutorial: The Basics](#griffy)       | English            |
 | [Traditional Animation Workflows](#david)      | English            |
-| [How to rotate image](#rotate)                 | English            |
+| [How to Rotate An Image](#rotate)              | English            |
 | [Scrolling background in Camera layer](#ca)    | No Audio           |
 | [Other Pencil English Tutorials](#pcleng)      | English            |
 | [Spanish Pencil2D Video Tutorials](#pclspa)    | Spanish            |
@@ -34,8 +34,7 @@ tagline: Learn how to use & animate with Pencil2D!
 <hr>
 
 # <a name="rotate"></a> How to Rotate an Image
-
-{% include youtubePlayer.html vid="8AzdWEDPBG0" %}
+{% include youtubePlayer.html vid="c4AH-gmEvXg" %}
 
 <hr>
 


### PR DESCRIPTION
Saw that the current video for rotating images was privated for a while, decided to create a video to showcase the rotate image feature in addition to the discrete rotate feature added in update 0.6.5 to replace the currently defunct link. Although the forums and discord server do have instructions on how to rotate images normally and in discrete angle rotations, I thought it would also help to have a readily accessible video in the tutorial section as well.

Tested the changes locally via Jekyll so I believe the link should work at least for desktop, though the change is very minimal (just replaced the video link) so it should work for other platforms as well. 

Let me know if you have any questions or feedback about the video itself and thanks for reading through this, I really appreciate it.

Youtube Link: https://youtu.be/c4AH-gmEvXg

Currently:
<img width="913" alt="Screen Shot 2023-12-09 at 10 38 27 PM" src="https://github.com/pencil2d/pencil2d.github.io/assets/81600208/aed66342-5be6-4086-8da7-3439ca22ff8c">

After:
<img width="880" alt="Screen Shot 2023-12-09 at 10 18 39 PM" src="https://github.com/pencil2d/pencil2d.github.io/assets/81600208/c3b1f387-839c-44cc-8ff7-5c3b480b787b">
