### PR TITLE
Add news post for 0.7.0-rc1

### DIFF
--- a/_posts/2024-06-19-pencil2d-0.7.0-rc1-release.md
+++ b/_posts/2024-06-19-pencil2d-0.7.0-rc1-release.md
@@ -1,0 +1,33 @@
+---
+layout: post
+title: "Calling all users, new release incoming!"
+tagline: ""
+categories: "News"
+author: "The Pencil2D Team"
+date: "2024-06-19"
+published: false
+comments: false
+---
+
+Since the last stable Pencil2D release, we’ve been hard at work behind-the-scenes to make Pencil2D better. If you’ve tried out our nightly builds at some point you’ve had a small taste of that work, but now we are on the verge of a new release and we need your help!
+
+Right now we are testing what will likely become v0.7.0 of Pencil2D and it would help us out a lot if as many of our wonderful users as possible could give this version a try as well! It contains a whole lot of bug fixes and new features, the full list of which will be shared when we do the full release. The purpose of this brief testing period is to make sure that there aren’t any major issues that we have missed.
+
+The more people we can get testing this “release candidate” version, the more confident we can be that we will be providing the best experience possible to all our users once we make the new release official, which will hopefully happen within the next couple of weeks.
+
+If you want to help us test the upcoming release, you can download it directly from these links:
+- [Windows 7+ 64-Bit](https://github.com/pencil2d/pencil/releases/download/v0.7.0-rc1/pencil2d-win64-0.7.0-rc1.zip)
+- [Windows 7+ 32-bit](https://github.com/pencil2d/pencil/releases/download/v0.7.0-rc1/pencil2d-win32-0.7.0-rc1.zip)
+- [macOS 10.13+](https://github.com/pencil2d/pencil/releases/download/v0.7.0-rc1/pencil2d-mac-0.7.0-rc1.zip)
+- [Linux amd64 AppImage](https://github.com/pencil2d/pencil/releases/download/v0.7.0-rc1/pencil2d-linux-amd64-0.7.0-rc1.AppImage)
+- [Linux i386 AppImage](https://github.com/pencil2d/pencil/releases/download/v0.7.0-rc1/pencil2d-linux-i386-0.7.0-rc1.AppImage)
+- Other: For official releases on other platforms, you will have to wait for the full release.
+
+> *Notes on compatibility*
+You can have multiple versions of Pencil2D installed on your computer, but please do not have multiple versions running at the same time. You can freely open projects made with older versions of Pencil2D with this version of Pencil2D, and open projects made with this version in older versions. Making backups of your projects is always recommended but is not required.
+
+Thank you for taking the time to read this and thank you to everyone who has helped by testing the nightly builds or will help in testing this release candidate. Pencil2D is created and maintained by a very small group of volunteers and it would be impossible for us to thoroughly test it without the help of our community.
+
+If you have any questions about this new release, there are multiple channels you can reach us through. Either our Discord server or our forums are good places to bring up any questions or issues you have about this release and to share feedback on any testing of this version that you manage to do. If you are in the Discord server, please try to use the #help-me channel for questions, and #bug-discussion for any testing feedback. If you prefer to use our forums, try to tag your posts with the “release-candidate” tag and place it in the Installing Pencil2D/How to category for questions, and Bug Reports for feedback.
+
+Also keep an eye on the #general channel in Discrod as we will be holding an animation challenge there shortly to promote the upcoming release and may have other things in the works as well 😉


### PR DESCRIPTION
A news post that we can link to on all platforms announcing the 0.7.0 release candidate and describing how users can help test it.

Preview it here: https://scribblemaniac.github.io/pencil2d.github.io/2024/06/pencil2d-0.7.0-rc1-release.html