### PR TITLE
Update "run" docs for MacOS Sonoma Security

### DIFF
--- a/download/index.md
+++ b/download/index.md
@@ -147,7 +147,10 @@ Previous Pencil2D releases are available on [the GitHub Releases][gh-releases].
 
 - **macOS: Pencil2D can't be opened because it is from an unidentified developer**
 
-    Right click on the file and press `Open`.
+    1. Right click on the file and press `Open`.
+    2. If this fails, on **MacOS 15 Sequoia**: after you’ve tried to open the application, go into Settings → Privacy & Security, scroll down to the bottom to see, '“Pencil2D” was blocked to protect your Mac.' Click “Open Anyway” next to this, and then see a dialog pop up. Finally click “Open Anyway” on the dialog and authenticate with a password if requested.
+
+
 
 Still having trouble? Please go to the [Pencil2D forum](https://discuss.pencil2d.org/c/support).
 

--- a/download/index.md
+++ b/download/index.md
@@ -148,7 +148,7 @@ Previous Pencil2D releases are available on [the GitHub Releases][gh-releases].
 - **macOS: Pencil2D can't be opened because it is from an unidentified developer**
 
     1. Right click on the file and press `Open`.
-    2. If the app still fails to open on **MacOS 15 Sequoia**: after trying to open the application, go into Settings → Privacy & Security, scroll down to the bottom to see, '“Pencil2D” was blocked to protect your Mac.' Click “Open Anyway” next to this, and then see a dialog pop up. Finally click “Open Anyway” on the dialog and authenticate with a password if requested.
+    2. If the app still fails to open on **MacOS 15 Sequoia**: after trying to open the application, go into Settings → Privacy & Security, scroll down to the bottom to see, '“Pencil2D” was blocked to protect your Mac.' Click “Open Anyway” next to this, and then see a dialog pop up. Finally click “Open Anyway” on the dialog, and authenticate with a password if requested.
 
 Still having trouble? Please go to the [Pencil2D forum](https://discuss.pencil2d.org/c/support).
 

--- a/download/index.md
+++ b/download/index.md
@@ -148,9 +148,7 @@ Previous Pencil2D releases are available on [the GitHub Releases][gh-releases].
 - **macOS: Pencil2D can't be opened because it is from an unidentified developer**
 
     1. Right click on the file and press `Open`.
-    2. If this fails, on **MacOS 15 Sequoia**: after you’ve tried to open the application, go into Settings → Privacy & Security, scroll down to the bottom to see, '“Pencil2D” was blocked to protect your Mac.' Click “Open Anyway” next to this, and then see a dialog pop up. Finally click “Open Anyway” on the dialog and authenticate with a password if requested.
-
-
+    2. If the app still fails to open on **MacOS 15 Sequoia**: after trying to open the application, go into Settings → Privacy & Security, scroll down to the bottom to see, '“Pencil2D” was blocked to protect your Mac.' Click “Open Anyway” next to this, and then see a dialog pop up. Finally click “Open Anyway” on the dialog and authenticate with a password if requested.
 
 Still having trouble? Please go to the [Pencil2D forum](https://discuss.pencil2d.org/c/support).
 


### PR DESCRIPTION
* Add FTUE run instructions for MacOS Sonoma users
* To run for the first time on MacOS Sonoma, users are required to approve unsigned applications through the System Settings  
* Per https://discuss.pencil2d.org/t/download-failed-on-macos/9404/2?u=nrichards